### PR TITLE
Feat/client name

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -34,7 +34,7 @@ def validate_client(data):
 
     if name == "":
         errors["name"] = "Por favor ingrese un nombre"
-    elif not re.match(r'^[a-zA-Z ]+$', name):
+    elif not re.match(r'^[a-zA-ZáéíóúÁÉÍÓÚüÜñÑ ]+$', name):
         errors["name"] = "El nombre solo puede contener letras y espacios"
 
     if phone == "":

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,6 @@
-from enum import Enum
 import re
+from enum import Enum
+
 from django.db import models
 
 

--- a/app/models.py
+++ b/app/models.py
@@ -1,5 +1,5 @@
 from enum import Enum
-
+import re
 from django.db import models
 
 
@@ -34,6 +34,8 @@ def validate_client(data):
 
     if name == "":
         errors["name"] = "Por favor ingrese un nombre"
+    elif not re.match(r'^[a-zA-Z ]+$', name):
+        errors["name"] = "El nombre solo puede contener letras y espacios"
 
     if phone == "":
         errors["phone"] = "Por favor ingrese un teléfono"

--- a/app/templates/clients/form.html
+++ b/app/templates/clients/form.html
@@ -30,9 +30,7 @@
                         required/>
 
                     {% if errors.name %}
-                        <div class="invalid-feedback">
-                            {{ errors.name }}
-                        </div>
+                    <div style="color: #ea868f; font-size: 0.875rem; margin-top: 0.25rem;"> {{errors.name}} </div>
                     {% endif %}
                 </div>
                 <div>

--- a/app/tests_integration.py
+++ b/app/tests_integration.py
@@ -54,6 +54,19 @@ class ClientsTest(TestCase):
         self.assertContains(response, "Por favor ingrese un nombre")
         self.assertContains(response, "Por favor ingrese un teléfono")
         self.assertContains(response, "Por favor ingrese un email")
+    
+    def test_validation_invalid_name(self):
+        response = self.client.post(
+            reverse("clients_form"),
+            data={
+                "name": "carlos54",
+                "phone": "54221555232",
+                "address": "13 y 44",
+                "email": "carlix@gmail.com",
+            },
+        )
+
+        self.assertContains(response, "El nombre solo puede contener letras y espacios")
 
     def test_should_response_with_404_status_if_client_doesnt_exists(self):
         response = self.client.get(reverse("clients_edit", kwargs={"id": 100}))

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -23,6 +23,18 @@ class ClientModelTest(TestCase):
         self.assertEqual(clients[0].address, "13 y 44")
         self.assertEqual(clients[0].email, "brujita75@hotmail.com")
 
+    def test_cant_create_client_with_error(self):
+        Client.save_client(
+            {
+                "name": "",
+                "phone": "221555232",
+                "address": "13 y 44",
+                "email": ""
+            },
+        )
+        clients = Client.objects.all()
+        self.assertEqual(len(clients), 0)
+
     def test_can_update_client(self):
         Client.save_client(
             {

--- a/app/tests_unit.py
+++ b/app/tests_unit.py
@@ -29,7 +29,7 @@ class ClientModelTest(TestCase):
                 "name": "",
                 "phone": "221555232",
                 "address": "13 y 44",
-                "email": ""
+                "email": "",
             },
         )
         clients = Client.objects.all()

--- a/functional_tests/tests.py
+++ b/functional_tests/tests.py
@@ -194,12 +194,14 @@ class ClientCreateEditTestCase(PlaywrightTestCase):
         expect(self.page.get_by_text("Por favor ingrese un teléfono")).to_be_visible()
         expect(self.page.get_by_text("Por favor ingrese un email")).to_be_visible()
 
-        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron")
+        self.page.get_by_label("Nombre").fill("Juan Sebastián Veron54")
         self.page.get_by_label("Teléfono").fill("221555232")
         self.page.get_by_label("Email").fill("brujita75")
         self.page.get_by_label("Dirección").fill("13 y 44")
-
+    
         self.page.get_by_role("button", name="Guardar").click()
+
+        expect(self.page.get_by_text("El nombre solo puede contener letras y espacios")).to_be_visible()
 
         expect(self.page.get_by_text("Por favor ingrese un nombre")).not_to_be_visible()
         expect(


### PR DESCRIPTION
Se modifico la función validate_client, para que compruebe que solo se pueda ingresar letras (incluidas tildes, ñ, diéresis) y espacios en el nombre. Además se agregaron o modificaron los tests pertinentes para validar esta nueva funcionalidad.